### PR TITLE
Fix issue with some has flag detection

### DIFF
--- a/src/StaticOptimizePlugin.ts
+++ b/src/StaticOptimizePlugin.ts
@@ -1,5 +1,5 @@
 import * as Compiler from 'webpack/lib/Compiler';
-import { Program, VariableDeclaration } from 'estree';
+import { Identifier, Program, VariableDeclaration } from 'estree';
 import walk from './util/walk';
 import ConstDependency = require('webpack/lib/dependencies/ConstDependency');
 import NormalModule = require('webpack/lib/NormalModule');
@@ -62,9 +62,8 @@ export default class HasPlugin {
 								if (callee.type === 'Identifier' && callee.name === 'require' && args.length === 1) {
 									const [ arg ] = args;
 									if (arg.type === 'Literal' && typeof arg.value === 'string' && HAS_MID.test(arg.value)) {
-										if (id.type === 'Identifier') {
-											hasIdentifier = id.name;
-										}
+										// casting as `id` will always be an Identifier, but this isn't known to the compiler
+										hasIdentifier = (id as Identifier).name;
 										found = true;
 									}
 								}

--- a/src/StaticOptimizePlugin.ts
+++ b/src/StaticOptimizePlugin.ts
@@ -45,69 +45,66 @@ export default class HasPlugin {
 			data.normalModuleFactory.plugin('parser', (parser) => {
 				// we need direct access to the AST to properly figure out the has substitution
 				parser.plugin('program', (ast: Program) => {
-					// some guards to help ensure we are only deaing with modules we care about
-					if (parser.state && parser.state.current && parser.state.current instanceof NormalModule) {
-						// Get all the top level variable declarations
-						const variableDeclarations = ast.body.filter((node) => {
-							if (!Array.isArray(node) && node.type === 'VariableDeclaration') {
-								return true;
-							}
-						}) as VariableDeclaration[];
-
-						// Look for `require('*/has');` and set the variable name to `hasIdentifier`
-						let hasIdentifier: string | undefined;
-						variableDeclarations.find(({ declarations }) => {
-							let found = false;
-							declarations.forEach(({ id, init }) => {
-								if (init && !Array.isArray(init) && init.type === 'CallExpression') {
-									const { callee, arguments: args } = init;
-									if (callee.type === 'Identifier' && callee.name === 'require' && args.length === 1) {
-										const [ arg ] = args;
-										if (arg.type === 'Literal' && typeof arg.value === 'string' && HAS_MID.test(arg.value)) {
-											if (id.type === 'Identifier') {
-												hasIdentifier = id.name;
-											}
-											found = true;
-										}
-									}
-								}
-							});
-							return found;
-						});
-
-						if (!hasIdentifier) {
-							// This doesn't import `has`
-							return;
+					// Get all the top level variable declarations
+					const variableDeclarations = ast.body.filter((node) => {
+						if (!Array.isArray(node) && node.type === 'VariableDeclaration') {
+							return true;
 						}
+					}) as VariableDeclaration[];
 
-						// Now we want to walk the AST and find an expressions where the default import of `*/has` is
-						// called.  Which is a CallExpression, where the callee is an object named the import from above
-						// accessing the `default` property, with one argument, which is a string literal.
-						walk(ast, {
-							enter(node, parent, prop, index) {
-								if (node.type === 'CallExpression') {
-									this.skip();
-									const { arguments: args, callee } = node;
-									if (callee.type === 'MemberExpression' && callee.object.type === 'Identifier' &&
-										callee.object.name === hasIdentifier && callee.property.type === 'Identifier' &&
-										callee.property.name === 'default' && args.length === 1) {
-										const [ arg ] = args;
-										if (arg.type === 'Literal' && typeof arg.value === 'string') {
-											// check to see if we have a flag that we want to statically swap
-											if (arg.value in features) {
-												const dep = new ConstDependency(features[arg.value] ? 'true' : 'false', node.range);
-												dep.loc = node.loc;
-												parser.state.current.addDependency(dep);
-											}
-											else {
-												dynamicFlags.add(arg.value);
-											}
+					// Look for `require('*/has');` and set the variable name to `hasIdentifier`
+					let hasIdentifier: string | undefined;
+					variableDeclarations.find(({ declarations }) => {
+						let found = false;
+						declarations.forEach(({ id, init }) => {
+							if (init && !Array.isArray(init) && init.type === 'CallExpression') {
+								const { callee, arguments: args } = init;
+								if (callee.type === 'Identifier' && callee.name === 'require' && args.length === 1) {
+									const [ arg ] = args;
+									if (arg.type === 'Literal' && typeof arg.value === 'string' && HAS_MID.test(arg.value)) {
+										if (id.type === 'Identifier') {
+											hasIdentifier = id.name;
 										}
+										found = true;
 									}
 								}
 							}
 						});
+						return found;
+					});
+
+					if (!hasIdentifier) {
+						// This doesn't import `has`
+						return;
 					}
+
+					// Now we want to walk the AST and find an expressions where the default import of `*/has` is
+					// called.  Which is a CallExpression, where the callee is an object named the import from above
+					// accessing the `default` property, with one argument, which is a string literal.
+					walk(ast, {
+						enter(node, parent, prop, index) {
+							if (node.type === 'CallExpression') {
+								const { arguments: args, callee } = node;
+								if (callee.type === 'MemberExpression' && callee.object.type === 'Identifier' &&
+									callee.object.name === hasIdentifier && callee.property.type === 'Identifier' &&
+									callee.property.name === 'default' && args.length === 1) {
+									this.skip();
+									const [ arg ] = args;
+									if (arg.type === 'Literal' && typeof arg.value === 'string') {
+										// check to see if we have a flag that we want to statically swap
+										if (arg.value in features) {
+											const dep = new ConstDependency(features[arg.value] ? 'true' : 'false', node.range);
+											dep.loc = node.loc;
+											parser.state.current.addDependency(dep);
+										}
+										else {
+											dynamicFlags.add(arg.value);
+										}
+									}
+								}
+							}
+						}
+					});
 				});
 			});
 		});

--- a/tests/support/fixtures/ast-has-call-in-call.json
+++ b/tests/support/fixtures/ast-has-call-in-call.json
@@ -1,0 +1,613 @@
+{
+  "type": "Program",
+  "start": 0,
+  "end": 150,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 5,
+      "column": 0
+    }
+  },
+  "range": [
+    0,
+    150
+  ],
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "start": 0,
+      "end": 13,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 13
+        }
+      },
+      "range": [
+        0,
+        13
+      ],
+      "expression": {
+        "type": "Literal",
+        "start": 0,
+        "end": 12,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 12
+          }
+        },
+        "range": [
+          0,
+          12
+        ],
+        "value": "use strict",
+        "raw": "\"use strict\""
+      }
+    },
+    {
+      "type": "ExpressionStatement",
+      "start": 14,
+      "end": 76,
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 0
+        },
+        "end": {
+          "line": 2,
+          "column": 62
+        }
+      },
+      "range": [
+        14,
+        76
+      ],
+      "expression": {
+        "type": "CallExpression",
+        "start": 14,
+        "end": 75,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 61
+          }
+        },
+        "range": [
+          14,
+          75
+        ],
+        "callee": {
+          "type": "MemberExpression",
+          "start": 14,
+          "end": 35,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 21
+            }
+          },
+          "range": [
+            14,
+            35
+          ],
+          "object": {
+            "type": "Identifier",
+            "start": 14,
+            "end": 20,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 0
+              },
+              "end": {
+                "line": 2,
+                "column": 6
+              }
+            },
+            "range": [
+              14,
+              20
+            ],
+            "name": "Object"
+          },
+          "property": {
+            "type": "Identifier",
+            "start": 21,
+            "end": 35,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 7
+              },
+              "end": {
+                "line": 2,
+                "column": 21
+              }
+            },
+            "range": [
+              21,
+              35
+            ],
+            "name": "defineProperty"
+          },
+          "computed": false
+        },
+        "arguments": [
+          {
+            "type": "Identifier",
+            "start": 36,
+            "end": 43,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 22
+              },
+              "end": {
+                "line": 2,
+                "column": 29
+              }
+            },
+            "range": [
+              36,
+              43
+            ],
+            "name": "exports"
+          },
+          {
+            "type": "Literal",
+            "start": 45,
+            "end": 57,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 31
+              },
+              "end": {
+                "line": 2,
+                "column": 43
+              }
+            },
+            "range": [
+              45,
+              57
+            ],
+            "value": "__esModule",
+            "raw": "\"__esModule\""
+          },
+          {
+            "type": "ObjectExpression",
+            "start": 59,
+            "end": 74,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 45
+              },
+              "end": {
+                "line": 2,
+                "column": 60
+              }
+            },
+            "range": [
+              59,
+              74
+            ],
+            "properties": [
+              {
+                "type": "Property",
+                "start": 61,
+                "end": 72,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 47
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 58
+                  }
+                },
+                "range": [
+                  61,
+                  72
+                ],
+                "method": false,
+                "shorthand": false,
+                "computed": false,
+                "key": {
+                  "type": "Identifier",
+                  "start": 61,
+                  "end": 66,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 47
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 52
+                    }
+                  },
+                  "range": [
+                    61,
+                    66
+                  ],
+                  "name": "value"
+                },
+                "value": {
+                  "type": "Literal",
+                  "start": 68,
+                  "end": 72,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 54
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 58
+                    }
+                  },
+                  "range": [
+                    68,
+                    72
+                  ],
+                  "value": true,
+                  "raw": "true"
+                },
+                "kind": "init"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "VariableDeclaration",
+      "start": 77,
+      "end": 114,
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 37
+        }
+      },
+      "range": [
+        77,
+        114
+      ],
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "start": 81,
+          "end": 113,
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 4
+            },
+            "end": {
+              "line": 3,
+              "column": 36
+            }
+          },
+          "range": [
+            81,
+            113
+          ],
+          "id": {
+            "type": "Identifier",
+            "start": 81,
+            "end": 86,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 4
+              },
+              "end": {
+                "line": 3,
+                "column": 9
+              }
+            },
+            "range": [
+              81,
+              86
+            ],
+            "name": "has_1"
+          },
+          "init": {
+            "type": "CallExpression",
+            "start": 89,
+            "end": 113,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 12
+              },
+              "end": {
+                "line": 3,
+                "column": 36
+              }
+            },
+            "range": [
+              89,
+              113
+            ],
+            "callee": {
+              "type": "Identifier",
+              "start": 89,
+              "end": 96,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 12
+                },
+                "end": {
+                  "line": 3,
+                  "column": 19
+                }
+              },
+              "range": [
+                89,
+                96
+              ],
+              "name": "require"
+            },
+            "arguments": [
+              {
+                "type": "Literal",
+                "start": 97,
+                "end": 112,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 20
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 35
+                  }
+                },
+                "range": [
+                  97,
+                  112
+                ],
+                "value": "@dojo/has/has",
+                "raw": "\"@dojo/has/has\""
+              }
+            ]
+          }
+        }
+      ],
+      "kind": "var"
+    },
+    {
+      "type": "ExpressionStatement",
+      "start": 115,
+      "end": 149,
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 0
+        },
+        "end": {
+          "line": 4,
+          "column": 34
+        }
+      },
+      "range": [
+        115,
+        149
+      ],
+      "expression": {
+        "type": "CallExpression",
+        "start": 115,
+        "end": 148,
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 33
+          }
+        },
+        "range": [
+          115,
+          148
+        ],
+        "callee": {
+          "type": "MemberExpression",
+          "start": 115,
+          "end": 126,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 0
+            },
+            "end": {
+              "line": 4,
+              "column": 11
+            }
+          },
+          "range": [
+            115,
+            126
+          ],
+          "object": {
+            "type": "Identifier",
+            "start": 115,
+            "end": 122,
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 0
+              },
+              "end": {
+                "line": 4,
+                "column": 7
+              }
+            },
+            "range": [
+              115,
+              122
+            ],
+            "name": "console"
+          },
+          "property": {
+            "type": "Identifier",
+            "start": 123,
+            "end": 126,
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 8
+              },
+              "end": {
+                "line": 4,
+                "column": 11
+              }
+            },
+            "range": [
+              123,
+              126
+            ],
+            "name": "log"
+          },
+          "computed": false
+        },
+        "arguments": [
+          {
+            "type": "CallExpression",
+            "start": 127,
+            "end": 147,
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 12
+              },
+              "end": {
+                "line": 4,
+                "column": 32
+              }
+            },
+            "range": [
+              127,
+              147
+            ],
+            "callee": {
+              "type": "MemberExpression",
+              "start": 127,
+              "end": 140,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 12
+                },
+                "end": {
+                  "line": 4,
+                  "column": 25
+                }
+              },
+              "range": [
+                127,
+                140
+              ],
+              "object": {
+                "type": "Identifier",
+                "start": 127,
+                "end": 132,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 17
+                  }
+                },
+                "range": [
+                  127,
+                  132
+                ],
+                "name": "has_1"
+              },
+              "property": {
+                "type": "Identifier",
+                "start": 133,
+                "end": 140,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 18
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 25
+                  }
+                },
+                "range": [
+                  133,
+                  140
+                ],
+                "name": "default"
+              },
+              "computed": false
+            },
+            "arguments": [
+              {
+                "type": "Literal",
+                "start": 141,
+                "end": 146,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 26
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 31
+                  }
+                },
+                "range": [
+                  141,
+                  146
+                ],
+                "value": "foo",
+                "raw": "'foo'"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "sourceType": "module"
+}

--- a/tests/unit/StaticOptimizePlugin.ts
+++ b/tests/unit/StaticOptimizePlugin.ts
@@ -57,13 +57,13 @@ registerSuite({
 		assert.strictEqual(compiler.plugins['compilation'].length, 2, 'injects two compilation plugins');
 		assert.strictEqual(compiler.plugins['emit'].length, 1, 'injects one emit plugin');
 		assert.strictEqual(logStub.callCount, 3, 'should have logged to console three time');
-		assert.strictEqual(logStub.secondCall.args[0], 'Dynamic features: foo, bar, baz', 'should have logged properly');
+		assert.strictEqual(logStub.secondCall.args[0], 'Dynamic features: foo, bar, baz, qat', 'should have logged properly');
 		assert.strictEqual(addDependencyStub.callCount, 0, 'Should not have added a dependency');
 	}),
 
 	'static features': runPluginTest({ foo: true, bar: false }, 'ast-has', ({ addDependencyStub, logStub }) => {
 		assert.strictEqual(logStub.callCount, 3, 'should have logged to console three time');
-		assert.strictEqual(logStub.secondCall.args[0], 'Dynamic features: baz', 'should have logged properly');
+		assert.strictEqual(logStub.secondCall.args[0], 'Dynamic features: baz, qat', 'should have logged properly');
 		assert.strictEqual(addDependencyStub.callCount, 3, 'Should have replaced 3 expressions');
 		assert.instanceOf(addDependencyStub.firstCall.args[0], ConstDependency);
 		assert.strictEqual((addDependencyStub.firstCall.args[0] as ConstDependency).expression, 'true', 'should be a const "true"');
@@ -89,6 +89,14 @@ registerSuite({
 	'does not import has': runPluginTest({ foo: true }, 'ast-has-no-import', ({ addDependencyStub, logStub }) => {
 		assert.isFalse(logStub.called, 'should not have been called');
 		assert.isFalse(addDependencyStub.called, 'should not have been called');
+	}),
+
+	'call in call expression': runPluginTest({ foo: true }, 'ast-has-call-in-call', ({ addDependencyStub, logStub }) => {
+		assert.isFalse(logStub.called, 'should not have been called');
+		assert.strictEqual(addDependencyStub.callCount, 1, 'should have been called once');
+		assert.instanceOf(addDependencyStub.firstCall.args[0], ConstDependency);
+		assert.strictEqual((addDependencyStub.firstCall.args[0] as ConstDependency).expression, 'true', 'should be a const "true"');
+		assert.deepEqual<any>((addDependencyStub.firstCall.args[0] as ConstDependency).range, [ 127, 147 ], 'should have proper range');
 	}),
 
 	'no module compilation'() {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

**Description:**

This PR fixes an issue where some features were not properly detected in modules.

In particular, structures where `has()` was inside another call expression, the structure was being ignored.  So this now is statically optimised:

```ts
import has from '@dojo/has/has';

console.log(has('foo'));
```

In addition, this fixes an issue where the detection of `NormalModules` was not compatible between webpack 2 and webpack 3.  This detection though is ultimately unnecessary and therefore removed.
